### PR TITLE
bug : 업로드한 원본 사진을 썸네일로 전환하는 기능 안되는 문제 해결(#191)

### DIFF
--- a/src/main/java/com/plana/infli/service/SettingService.java
+++ b/src/main/java/com/plana/infli/service/SettingService.java
@@ -11,6 +11,7 @@ import com.plana.infli.exception.custom.BadRequestException;
 import com.plana.infli.exception.custom.ConflictException;
 import com.plana.infli.exception.custom.NotFoundException;
 import com.plana.infli.repository.member.MemberRepository;
+import com.plana.infli.service.aop.upload.Upload;
 import com.plana.infli.utils.S3Uploader;
 import com.plana.infli.web.dto.request.setting.modify.nickname.ModifyNicknameServiceRequest;
 import com.plana.infli.web.dto.request.setting.modify.password.ModifyPasswordServiceRequest;
@@ -122,7 +123,9 @@ public class SettingService {
     }
 
     @Transactional
-    public ChangeProfileImageResponse changeProfileImage(String username, MultipartFile multipartFile) {
+    @Upload
+    public ChangeProfileImageResponse changeProfileImage(String username,
+            MultipartFile multipartFile) {
 
         Member member = findMemberBy(username);
 

--- a/src/main/java/com/plana/infli/service/aop/upload/UploadAspect.java
+++ b/src/main/java/com/plana/infli/service/aop/upload/UploadAspect.java
@@ -1,40 +1,30 @@
 package com.plana.infli.service.aop.upload;
 
 import static com.plana.infli.exception.custom.InternalServerErrorException.IMAGE_UPLOAD_FAILED;
-import static com.plana.infli.exception.custom.InternalServerErrorException.POST_VIEW_FAILED;
 
 import com.plana.infli.exception.custom.InternalServerErrorException;
-import com.plana.infli.service.aop.retry.Retry;
 import java.io.IOException;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
-import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
 @Aspect
 @Component
 @Slf4j
+@Order(Ordered.LOWEST_PRECEDENCE - 1)
 public class UploadAspect {
 
 
     @Around("@annotation(upload)")
-    public Object doRetry(ProceedingJoinPoint joinPoint, Upload upload) throws Throwable {
-
-        int maxRetry = upload.value();
-
-        for (int retryCount = 1; retryCount <= maxRetry; retryCount++) {
-            try {
-                return joinPoint.proceed();
-            } catch (IOException e) {
-                try {
-                    log.info("[retry] try count={}/{}", retryCount, maxRetry);
-                    Thread.sleep(50);
-                } catch (InterruptedException ignored) {
-                }
-            }
+    public Object upload(ProceedingJoinPoint joinPoint, Upload upload) throws Throwable {
+        try {
+            return joinPoint.proceed();
+        } catch (IOException e) {
+            throw new InternalServerErrorException(IMAGE_UPLOAD_FAILED);
         }
-        throw new InternalServerErrorException(IMAGE_UPLOAD_FAILED);
     }
 }

--- a/src/main/java/com/plana/infli/utils/S3Uploader.java
+++ b/src/main/java/com/plana/infli/utils/S3Uploader.java
@@ -33,7 +33,6 @@ public class S3Uploader {
     private String bucket;
 
 
-    @Upload
     public String uploadAsOriginalImage(MultipartFile multipartFile, String directoryPath) {
 
         validateUploadedFile(multipartFile);
@@ -56,7 +55,6 @@ public class S3Uploader {
                 new PutObjectRequest(bucket, fullPathName, file).withCannedAcl(PublicRead));
     }
 
-    @Upload
     public String uploadAsThumbnailImage(MultipartFile multipartFile, String directoryPath) {
 
         validateUploadedFile(multipartFile);
@@ -88,12 +86,15 @@ public class S3Uploader {
 
     @SneakyThrows(IOException.class)
     private File generateThumbnailFile(String storeFileName, File uploadedFile) {
+
         File thumbnailFile = new File(storeFileName);
 
+        thumbnailFile.createNewFile();
+
         Thumbnails.of(uploadedFile)
-                .size(64, 64)
-                .outputFormat("jpeg")
+                .size(300, 300)
                 .toFile(thumbnailFile);
+
         return thumbnailFile;
     }
 

--- a/src/main/java/com/plana/infli/web/dto/request/member/signup/company/CreateCompanyMemberRequest.java
+++ b/src/main/java/com/plana/infli/web/dto/request/member/signup/company/CreateCompanyMemberRequest.java
@@ -46,5 +46,4 @@ public class CreateCompanyMemberRequest {
                 .companyName(companyName)
                 .build();
     }
-
 }


### PR DESCRIPTION
(#191) 업로드한 원본 사진을 썸네일로 전환하는 기능 안되는 문제 해결

## 작업 내용

- 원본사진을 썸네일 사진으로 전환하는 기능 안되는 문제 해결 

## 닫힌 이슈

close #191 