### PR TITLE
bug : 내가 작성한 글 목록 조회시 빈 배열이 반환되는 문제 해결 (283)

### DIFF
--- a/src/main/java/com/plana/infli/repository/post/PostRepositoryImpl.java
+++ b/src/main/java/com/plana/infli/repository/post/PostRepositoryImpl.java
@@ -164,7 +164,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
 
         setCommentCount(ids, posts);
 
-        return null;
+        return posts;
     }
 
     private List<Long> findMyPostIds(PostQueryRequest request) {
@@ -176,6 +176,11 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                 .limit(request.getSize())
                 .fetch();
     }
+
+    private BooleanExpression postIsActiveAndWriterEqual(Member findMember) {
+        return postIsActive().and(postWriterEqual(findMember));
+    }
+
 
     private List<MyPost> findMyPosts(List<Long> ids, Member findMember) {
 
@@ -275,9 +280,6 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
     }
 
 
-    private BooleanExpression postIsActiveAndWriterEqual(Member findMember) {
-        return postIsActive().and(postWriterEqual(findMember));
-    }
 
 
 

--- a/src/main/java/com/plana/infli/web/dto/response/post/my/MyPostsResponse.java
+++ b/src/main/java/com/plana/infli/web/dto/response/post/my/MyPostsResponse.java
@@ -23,6 +23,7 @@ public class MyPostsResponse extends DefaultPostsResponse {
         return MyPostsResponse.builder()
                 .sizeRequest(request.getSize())
                 .currentPage(request.getPage())
+                .actualSize(posts.size())
                 .posts(posts)
                 .build();
     }


### PR DESCRIPTION
Signed-off-by: jin8743 youngjin8743@gmail.com

(#283) 내가 작성한 글 목록 조회시 빈 배열이 반환되는 문제 해결

## 작업 내용

- 내가 작성한 글 목록 조회 시 글이 조회 되지 않고 빈 배열이 반환 되는 문제 해결

## 닫힌 이슈

close #283 
