### PR TITLE
bug : 글 단건 조회시 댓글 갯수가 항상 0개로 응답되는 문제 해결 (291)

### DIFF
--- a/src/main/java/com/plana/infli/web/dto/response/post/search/SearchedPostsResponse.java
+++ b/src/main/java/com/plana/infli/web/dto/response/post/search/SearchedPostsResponse.java
@@ -21,8 +21,9 @@ public class SearchedPostsResponse {
     private final int currentPage;
 
     @Builder
-    private SearchedPostsResponse(int sizeRequest, int actualSize, int currentPage,
-            List<SearchedPost> posts) {
+    private SearchedPostsResponse(int sizeRequest, int actualSize,
+            int currentPage, List<SearchedPost> posts) {
+
         this.sizeRequest = sizeRequest;
         this.actualSize = actualSize;
         this.currentPage = currentPage;


### PR DESCRIPTION
Signed-off-by: jin8743 youngjin8743@gmail.com

(#291) 글 단건 조회시 댓글 갯수가 항상 0개로 응답되는 문제 해결

## 작업 내용

글 단건 조회시 댓글 갯수가 항상 0개로 응답되는 문제 해결

## 닫힌 이슈

close #291 
