### PR TITLE
feat  : 비밀번호 검증, 닉네임 변경 API 코드 리펙토링 (321)

### DIFF
--- a/src/main/java/com/plana/infli/service/SettingService.java
+++ b/src/main/java/com/plana/infli/service/SettingService.java
@@ -22,7 +22,9 @@ import com.plana.infli.infra.exception.custom.NotFoundException;
 import com.plana.infli.repository.member.MemberRepository;
 import com.plana.infli.service.aop.upload.Upload;
 import com.plana.infli.service.util.S3Uploader;
+import com.plana.infli.web.dto.request.setting.modify.nickname.ModifyNicknameServiceRequest;
 import com.plana.infli.web.dto.request.setting.modify.password.ModifyPasswordServiceRequest;
+import com.plana.infli.web.dto.request.setting.verify.password.VerifyPasswordServiceRequest;
 import com.plana.infli.web.dto.response.profile.MyProfileResponse;
 import com.plana.infli.web.dto.response.profile.MyProfileToUnregisterResponse;
 import com.plana.infli.web.dto.response.profile.image.ChangeProfileImageResponse;
@@ -68,20 +70,20 @@ public class SettingService {
     }
 
     @Transactional
-    public void changeNickname(String username, String newNickname) {
+    public void changeNickname(ModifyNicknameServiceRequest request) {
 
-        Member member = findMemberBy(username);
+        Member member = findMemberBy(request.getUsername());
 
-        checkIsAvailableNewNickname(newNickname);
+        checkIsAvailableNewNickname(request.getNickname());
 
-        editNickname(member, newNickname);
+        editNickname(member, request.getNickname());
     }
 
-    public String verifyCurrentPassword(String username, String currentPassword) {
+    public String verifyCurrentPassword(VerifyPasswordServiceRequest request) {
 
-        Member member = findMemberBy(username);
+        Member member = findMemberBy(request.getUsername());
 
-        return checkPasswordMatches(member, currentPassword);
+        return checkPasswordMatches(member, request.getPassword());
     }
 
     private String checkPasswordMatches(Member member, String password) {

--- a/src/main/java/com/plana/infli/web/controller/SettingController.java
+++ b/src/main/java/com/plana/infli/web/controller/SettingController.java
@@ -1,7 +1,9 @@
 package com.plana.infli.web.controller;
 
 import com.plana.infli.service.SettingService;
+import com.plana.infli.web.dto.request.setting.modify.nickname.ModifyNicknameRequest;
 import com.plana.infli.web.dto.request.setting.modify.password.ModifyPasswordRequest;
+import com.plana.infli.web.dto.request.setting.verify.password.VerifyPasswordRequest;
 import com.plana.infli.web.dto.response.profile.MyProfileResponse;
 import com.plana.infli.web.dto.response.profile.MyProfileToUnregisterResponse;
 import com.plana.infli.web.dto.response.profile.image.ChangeProfileImageResponse;
@@ -39,19 +41,17 @@ public class SettingController {
 
     @PostMapping("/nickname")
     @Operation(summary = "회원 닉네임 변경")
-    public String changeNickname(@AuthenticatedPrincipal String username,
-            @RequestBody String newNickname) {
-
-        settingService.changeNickname(username, newNickname);
-        return "닉네임 변경 완료";
+    public void changeNickname(@AuthenticatedPrincipal String username,
+            @RequestBody @Validated ModifyNicknameRequest request) {
+        settingService.changeNickname(request.toServiceRequest(username));
     }
 
     @PostMapping("/password/verification")
     @Operation(summary = "기존 비밀번호 검증")
     public String verifyCurrentPassword(@AuthenticatedPrincipal String username,
-            @RequestBody String currentPassword) {
+            @RequestBody @Validated VerifyPasswordRequest request) {
 
-        return settingService.verifyCurrentPassword(username, currentPassword);
+        return settingService.verifyCurrentPassword(request.toServiceRequest(username));
     }
 
     @PostMapping("/password")

--- a/src/main/java/com/plana/infli/web/dto/request/setting/modify/nickname/ModifyNicknameRequest.java
+++ b/src/main/java/com/plana/infli/web/dto/request/setting/modify/nickname/ModifyNicknameRequest.java
@@ -1,0 +1,26 @@
+package com.plana.infli.web.dto.request.setting.modify.nickname;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ModifyNicknameRequest {
+
+    @NotEmpty(message = "변경할 새 닉네임을 입력해주세요")
+    private String nickname;
+
+    @Builder
+    private ModifyNicknameRequest(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public ModifyNicknameServiceRequest toServiceRequest(String username) {
+        return ModifyNicknameServiceRequest.builder()
+                .username(username)
+                .nickname(nickname)
+                .build();
+    }
+}

--- a/src/main/java/com/plana/infli/web/dto/request/setting/modify/nickname/ModifyNicknameServiceRequest.java
+++ b/src/main/java/com/plana/infli/web/dto/request/setting/modify/nickname/ModifyNicknameServiceRequest.java
@@ -1,0 +1,18 @@
+package com.plana.infli.web.dto.request.setting.modify.nickname;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ModifyNicknameServiceRequest {
+
+    private final String username;
+
+    private final String nickname;
+
+    @Builder
+    private ModifyNicknameServiceRequest(String username, String nickname) {
+        this.username = username;
+        this.nickname = nickname;
+    }
+}

--- a/src/main/java/com/plana/infli/web/dto/request/setting/verify/password/VerifyPasswordRequest.java
+++ b/src/main/java/com/plana/infli/web/dto/request/setting/verify/password/VerifyPasswordRequest.java
@@ -1,0 +1,26 @@
+package com.plana.infli.web.dto.request.setting.verify.password;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class VerifyPasswordRequest {
+
+    @NotEmpty(message = "비밀번호를 입력해주세요")
+    private String password;
+
+    @Builder
+    private VerifyPasswordRequest(String password) {
+        this.password = password;
+    }
+
+    public VerifyPasswordServiceRequest toServiceRequest(String username) {
+        return VerifyPasswordServiceRequest.builder()
+                .username(username)
+                .password(password)
+                .build();
+    }
+}

--- a/src/main/java/com/plana/infli/web/dto/request/setting/verify/password/VerifyPasswordServiceRequest.java
+++ b/src/main/java/com/plana/infli/web/dto/request/setting/verify/password/VerifyPasswordServiceRequest.java
@@ -1,0 +1,18 @@
+package com.plana.infli.web.dto.request.setting.verify.password;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class VerifyPasswordServiceRequest {
+
+    private final String username;
+
+    private final String password;
+
+    @Builder
+    private VerifyPasswordServiceRequest(String username, String password) {
+        this.username = username;
+        this.password = password;
+    }
+}

--- a/src/test/java/com/plana/infli/controller/CommentControllerTest.java
+++ b/src/test/java/com/plana/infli/controller/CommentControllerTest.java
@@ -48,7 +48,6 @@ import org.springframework.test.web.servlet.ResultActions;
 @MockMvcTest
 class CommentControllerTest {
 
-
     @Autowired
     protected MockMvc mvc;
 

--- a/src/test/java/com/plana/infli/controller/SettingControllerTest.java
+++ b/src/test/java/com/plana/infli/controller/SettingControllerTest.java
@@ -26,7 +26,10 @@ import com.plana.infli.domain.Member;
 import com.plana.infli.repository.company.CompanyRepository;
 import com.plana.infli.repository.member.MemberRepository;
 import com.plana.infli.repository.university.UniversityRepository;
+import com.plana.infli.web.dto.request.comment.create.CreateCommentRequest;
+import com.plana.infli.web.dto.request.setting.modify.nickname.ModifyNicknameRequest;
 import com.plana.infli.web.dto.request.setting.modify.password.ModifyPasswordRequest;
+import com.plana.infli.web.dto.request.setting.verify.password.VerifyPasswordRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -215,9 +218,14 @@ class SettingControllerTest {
         //given
         Member member = findContextMember();
 
+        String json = om.writeValueAsString(ModifyNicknameRequest.builder()
+                .nickname("infli12")
+                .build());
+
         //when
         ResultActions resultActions = mvc.perform(post("/setting/nickname")
-                .content("infli12")
+                .contentType(APPLICATION_JSON)
+                .content(json)
                 .with(csrf()));
 
         //then
@@ -230,9 +238,14 @@ class SettingControllerTest {
     @DisplayName("닉네임 변경 실패 - 로그인을 하지 않은 경우")
     @Test
     void changeNicknameWithoutLogin() throws Exception {
+        //given
+        String json = om.writeValueAsString(ModifyNicknameRequest.builder()
+                .nickname("infli12")
+                .build());
         //when
         ResultActions resultActions = mvc.perform(post("/setting/nickname")
-                .content("infli12")
+                .contentType(APPLICATION_JSON)
+                .content(json)
                 .with(csrf()));
 
         //then
@@ -245,14 +258,20 @@ class SettingControllerTest {
     @WithMockMember
     @Test
     void changeNicknameWithEmptyString() throws Exception {
+        //given
+        String json = om.writeValueAsString(ModifyNicknameRequest.builder()
+                .nickname(null)
+                .build());
+
         //when
         ResultActions resultActions = mvc.perform(post("/setting/nickname")
-                .content("")
+                .contentType(APPLICATION_JSON)
+                .content(json)
                 .with(csrf()));
 
         //then
         resultActions.andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("요청 본문의 형식이 올바르지 않습니다"))
+                .andExpect(jsonPath("$.validation.nickname").value("변경할 새 닉네임을 입력해주세요"))
                 .andDo(print());
     }
 
@@ -260,12 +279,20 @@ class SettingControllerTest {
     @WithMockMember
     @Test
     void changeNicknameWithEmptyString2() throws Exception {
+        //given
+        String json = om.writeValueAsString(ModifyNicknameRequest.builder()
+                .nickname("")
+                .build());
+
         //when
-        ResultActions resultActions = mvc.perform(post("/setting/nickname"));
+        ResultActions resultActions = mvc.perform(post("/setting/nickname")
+                .contentType(APPLICATION_JSON)
+                .content(json)
+                .with(csrf()));
 
         //then
         resultActions.andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("요청 본문의 형식이 올바르지 않습니다"))
+                .andExpect(jsonPath("$.validation.nickname").value("변경할 새 닉네임을 입력해주세요"))
                 .andDo(print());
     }
 
@@ -273,9 +300,16 @@ class SettingControllerTest {
     @WithMockMember
     @Test
     void verifyCurrentPassword() throws Exception {
+        //given
+        String json = om.writeValueAsString(VerifyPasswordRequest.builder()
+                .password("password")
+                .build());
+
         //when
         ResultActions resultActions = mvc.perform(post("/setting/password/verification")
-                .content("password"));
+                .contentType(APPLICATION_JSON)
+                .content(json)
+                .with(csrf()));
 
         //then
         resultActions.andExpect(status().isOk())
@@ -286,10 +320,17 @@ class SettingControllerTest {
     @WithMockMember
     @Test
     void provideInvalidPassword() throws Exception {
+        //given
+        String json = om.writeValueAsString(VerifyPasswordRequest.builder()
+                .password("1111")
+                .build());
 
         //when
         ResultActions resultActions = mvc.perform(post("/setting/password/verification")
-                .content("1111"));
+                .contentType(APPLICATION_JSON)
+                .content(json)
+                .with(csrf()));
+
 
         //then
         resultActions.andExpect(status().isBadRequest())
@@ -300,9 +341,16 @@ class SettingControllerTest {
     @DisplayName("현재 사용중인 비밀번호 검증 실패 - 로그인을 하지 않은 경우")
     @Test
     void verifyCurrentPasswordWithoutLogin() throws Exception {
+        //given
+        String json = om.writeValueAsString(VerifyPasswordRequest.builder()
+                .password("1111")
+                .build());
+
         //when
         ResultActions resultActions = mvc.perform(post("/setting/password/verification")
-                .content("password"));
+                .contentType(APPLICATION_JSON)
+                .content(json)
+                .with(csrf()));
 
         //then
         resultActions.andExpect(status().isUnauthorized())
@@ -314,14 +362,20 @@ class SettingControllerTest {
     @WithMockMember
     @Test
     void verifyCurrentPasswordWithoutProvidingPassword() throws Exception {
+        //given
+        String json = om.writeValueAsString(VerifyPasswordRequest.builder()
+                .password(null)
+                .build());
 
         //when
         ResultActions resultActions = mvc.perform(post("/setting/password/verification")
-                .content(""));
+                .contentType(APPLICATION_JSON)
+                .content(json)
+                .with(csrf()));
 
         //then
         resultActions.andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("요청 본문의 형식이 올바르지 않습니다"))
+                .andExpect(jsonPath("$.validation.password").value("비밀번호를 입력해주세요"))
                 .andDo(print());
     }
 
@@ -329,13 +383,20 @@ class SettingControllerTest {
     @WithMockMember
     @Test
     void verifyCurrentPasswordWithoutProvidingPassword2() throws Exception {
+        //given
+        String json = om.writeValueAsString(VerifyPasswordRequest.builder()
+                .password("")
+                .build());
 
         //when
-        ResultActions resultActions = mvc.perform(post("/setting/password/verification"));
+        ResultActions resultActions = mvc.perform(post("/setting/password/verification")
+                .contentType(APPLICATION_JSON)
+                .content(json)
+                .with(csrf()));
 
         //then
         resultActions.andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("요청 본문의 형식이 올바르지 않습니다"))
+                .andExpect(jsonPath("$.validation.password").value("비밀번호를 입력해주세요"))
                 .andDo(print());
     }
 


### PR DESCRIPTION
Signed-off-by: jin8743 youngjin8743@gmail.com

(#321) 비밀번호 검증, 닉네임 변경 API 코드 리펙토링

## 핵심 변경 사항

- 비밀번호 검증, 닉네임 변경 API 요청시 요청값을 JSON 형태로 요청할수 있도록 변경 

## 닫힌 이슈

close #321 