### PR TITLE
bug : 특정 글에 댓글 작성시 해당 글의 조회수가 0이 되는 문제 해결 (362)

### DIFF
--- a/src/main/java/com/plana/infli/domain/Post.java
+++ b/src/main/java/com/plana/infli/domain/Post.java
@@ -99,6 +99,9 @@ public class Post extends BaseEntity {
         this.recruitment = postEditor.getRecruitment();
         this.isDeleted = postEditor.isDeleted();
         this.viewCount = postEditor.getViewCount();
-        this.commentMemberCount = postEditor.getCommentMemberCount();
+    }
+
+    public int increaseCommentMemberCount() {
+        return ++commentMemberCount;
     }
 }

--- a/src/main/java/com/plana/infli/domain/editor/PostEditor.java
+++ b/src/main/java/com/plana/infli/domain/editor/PostEditor.java
@@ -24,18 +24,16 @@ public class PostEditor {
 
     private final int viewCount;
 
-    private final int commentMemberCount;
 
     @Builder
     public PostEditor(String title, String content, String thumbnailUrl, Recruitment recruitment,
-            boolean isDeleted, int viewCount, int commentMemberCount) {
+            boolean isDeleted, int viewCount) {
         this.title = title;
         this.content = content;
         this.thumbnailUrl = thumbnailUrl;
         this.recruitment = recruitment;
         this.isDeleted = isDeleted;
         this.viewCount = viewCount;
-        this.commentMemberCount = commentMemberCount;
     }
 
 
@@ -72,17 +70,5 @@ public class PostEditor {
         post.edit(post.toEditor()
                 .viewCount(increasedViewCount)
                 .build());
-    }
-
-    public static int increaseCommentMemberCount(Post post) {
-        int currentCommentMemberCount = post.getCommentMemberCount();
-
-        int increasedCommentMemberCount = currentCommentMemberCount + 1;
-
-        post.edit(post.toEditor()
-                .commentMemberCount(increasedCommentMemberCount)
-                .build());
-
-        return increasedCommentMemberCount;
     }
 }

--- a/src/main/java/com/plana/infli/infra/initializer/DefaultInitializer.java
+++ b/src/main/java/com/plana/infli/infra/initializer/DefaultInitializer.java
@@ -101,6 +101,7 @@ public class DefaultInitializer implements CommandLineRunner {
     }
 
     private void createAdminMember() {
+        if (memberRepository.existsByRole(ADMIN) == false) {
             memberRepository.save(Member.builder()
                     .university(university)
                     .role(ADMIN)
@@ -111,5 +112,6 @@ public class DefaultInitializer implements CommandLineRunner {
                     .studentCredentials(null)
                     .companyCredentials(null)
                     .build());
+        }
     }
 }

--- a/src/main/java/com/plana/infli/service/CommentService.java
+++ b/src/main/java/com/plana/infli/service/CommentService.java
@@ -3,7 +3,6 @@ package com.plana.infli.service;
 import static com.plana.infli.domain.Comment.*;
 import static com.plana.infli.domain.Member.isAdmin;
 import static com.plana.infli.domain.editor.CommentEditor.*;
-import static com.plana.infli.domain.editor.PostEditor.increaseCommentMemberCount;
 import static com.plana.infli.domain.type.VerificationStatus.*;
 import static com.plana.infli.infra.exception.custom.BadRequestException.CHILD_COMMENTS_NOT_ALLOWED;
 import static com.plana.infli.infra.exception.custom.BadRequestException.EDIT_COMMENT_IN_DELETED_POST_NOT_ALLOWED;
@@ -151,7 +150,7 @@ public class CommentService {
 
             // 새로운 식별자 번호를 생성한후 부여한다
             // 이 글에 작성된 댓글들에게 부여된 가장 최근 식별자 번호
-            return increaseCommentMemberCount(post);
+            return post.increaseCommentMemberCount();
         }
 
         // 식별자 번호가 존재하는 경우 기존 번호 그대로 다시 부여한다


### PR DESCRIPTION
Signed-off-by: jin8743 youngjin8743@gmail.com

(#362) 특정 글에 댓글 작성시 해당 글의 조회수가 0이 되는 문제 해결 

## 작업 내용

- 특정글이 작성된 후, 글 작성자가 아닌 다른 회원이 해당 글에 처음으로 댓글을 단 경우, 해당 글의 조회수가 0으로 초기화 되는 문제 해결 

## 닫힌 이슈

close #362