### PR TITLE
chore : 인기글 선정 기준 변경 (367)

### DIFF
--- a/src/main/java/com/plana/infli/repository/post/PostRepositoryImpl.java
+++ b/src/main/java/com/plana/infli/repository/post/PostRepositoryImpl.java
@@ -279,9 +279,9 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
 
     //TODO 인기글 선정 기준
     private BooleanExpression postIsPopularPost() {
-        return post.commentMemberCount.goe(3)
-                .or(post.viewCount.goe(20)
-                        .or(post.likes.size().goe(3)));
+        return post.commentMemberCount.goe(5)
+                .or(post.viewCount.goe(80)
+                        .or(post.likes.size().goe(5)));
     }
 
     private BooleanExpression postTypeEqual(PostType postType) {


### PR DESCRIPTION
Signed-off-by: jin8743 youngjin8743@gmail.com

(#367) 인기글 선정 기준 변경

## 작업 내용

인기글 선정 기준 변경 

1. 좋아요 5개 이상
2. 조회수 80 이상
3. 댓글을 작성한 각기 다른 회원 5명 이상

이중 1개라도 충족시키는 글이 인기글로 선정되도록 기준을 변경

## 닫힌 이슈

close #367
