### PR TITLE
feat : 특정 게시판의 글 목록 조회 API 기능 개선 (378)

### DIFF
--- a/src/main/java/com/plana/infli/repository/post/PostRepositoryImpl.java
+++ b/src/main/java/com/plana/infli/repository/post/PostRepositoryImpl.java
@@ -240,7 +240,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                         getMemberRole(request.getBoard()), post.likes.size(),
                         pressedLikeOnThisPost(request.getMember()), post.viewCount,
                         post.recruitment.companyName, post.recruitment.startDate,
-                        post.recruitment.endDate))
+                        post.recruitment.endDate, post.thumbnailUrl.isNotNull()))
                 .from(post)
                 .where(post.id.in(ids))
                 .orderBy(post.id.desc())

--- a/src/main/java/com/plana/infli/web/dto/response/post/board/BoardPost.java
+++ b/src/main/java/com/plana/infli/web/dto/response/post/board/BoardPost.java
@@ -17,18 +17,21 @@ public class BoardPost extends DefaultPost {
 
     private final LocalDateTime recruitmentEndDate;
 
+    private final boolean hasImage;
+
 
     @Builder
     @QueryProjection
     public BoardPost(Long postId, String title, LocalDateTime createdAt,
             String thumbnailURL, String memberRole, int likeCount, boolean pressedLike,int viewCount,
             String companyName, LocalDateTime recruitmentStartDate,
-            LocalDateTime recruitmentEndDate) {
+            LocalDateTime recruitmentEndDate, boolean hasImage) {
         super(postId, title, pressedLike, likeCount, viewCount, createdAt, thumbnailURL);
 
         this.memberRole = memberRole;
         this.companyName = companyName;
         this.recruitmentStartDate = recruitmentStartDate;
         this.recruitmentEndDate = recruitmentEndDate;
+        this.hasImage = hasImage;
     }
 }


### PR DESCRIPTION
Signed-off-by: jin8743 youngjin8743@gmail.com

## 작업 내용

- 특정 게시판의 글 목록 조회시 해당 글에 사진 있는지 여부 boolean값으로 응답 

## 닫힌 이슈

close #378 